### PR TITLE
I think the instance role value in the "provisioning instance" step s…

### DIFF
--- a/wp-website/nginx/nginx-playbook.yml
+++ b/wp-website/nginx/nginx-playbook.yml
@@ -129,7 +129,7 @@
       security_token: "{{ assumed_role.sts_creds.session_token }}"
       key_name: "{{ key_name }}"
       image_id: "{{ latest_ami.image_id }}"
-      instance_role: "arn:aws:iam::{{ lookup('env', 'AWS_ACCOUNT_ID') }}:instance-profile/{{ service }}-rp-{{ env }}-role"
+      instance_role: "arn:aws:iam::{{ lookup('env', 'AWS_ACCOUNT_ID') }}:instance-profile/ansible-ami-role"
       instance_type: "t3a.large"
       metadata_options:
         http_endpoint: "enabled"


### PR DESCRIPTION
…hould match the name of the instance profile from line 71...

...it looks like the Instance Profile was renamed a few commits ago, but hasn't been kept in sync with the reference here.